### PR TITLE
fix: 修复拦截复读消息配置未生效的问题

### DIFF
--- a/main.py
+++ b/main.py
@@ -65,14 +65,14 @@ class BetterIOPlugin(Star):
 
         # 拦截重复消息
         msg = result.get_plain_text()
-        if msg and msg in g.bot_msgs:
+        iconf = self.conf["intercept"]
+        if iconf["reread_block"] and msg and msg in g.bot_msgs:
             event.set_result(event.plain_result(""))
             logger.info(f"已阻止发送重复消息：{msg}")
             return
         g.bot_msgs.append(msg)
 
         # 拦截错误信息(管理员触发的则不拦截)
-        iconf = self.conf["intercept"]
         if iconf["block_error"] and not event.is_admin():
             for word in iconf["error_words"]:
                 if word in msg:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,6 +2,6 @@ name: astrbot_plugin_outputpro # 这是你的插件的唯一识别名。
 display_name: 输出增强
 desc: 输出增强插件：报错拦截、文本清洗、随机@、随机引用 # 插件简短描述
 help: 略  # 插件的帮助信息
-version: v1.0.6 # 插件版本号。格式：v1.1.1 或者 v1.1
+version: v1.0.7 # 插件版本号。格式：v1.1.1 或者 v1.1
 author: Zhalslar # 作者
 repo: https://github.com/Zhalslar/astrbot_plugin_outputpro # 插件的仓库地址


### PR DESCRIPTION
## 由 Sourcery 生成的总结

启用可通过配置控制的重复机器人消息拦截，并提升插件版本。

错误修复：
- 在决定是否拦截重复的机器人消息时，遵循 `intercept.reread_block` 配置标志。

日常维护：
- 将插件元数据版本从 v1.0.6 更新为 v1.0.7。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable configuration-controlled blocking of repeated bot messages and bump the plugin version.

Bug Fixes:
- Respect the intercept.reread_block configuration flag when deciding whether to block repeated bot messages.

Chores:
- Update plugin metadata version from v1.0.6 to v1.0.7.

</details>