### PR TITLE
修复假艾特的解析

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -86,7 +86,7 @@
     "parse_at": {
         "description": "解析假艾特",
         "type": "bool",
-        "hint": "第四步：将消息中字符串式的假艾特转换成真艾特，包括：@username @id [at:username] [at:id] ,且忽略中英文和大小写",
+        "hint": "第四步：将消息中句首的假艾特转换成真艾特，包括：@username @id [at:username] [at:id] ,且忽略中英文和大小写",
         "default": true
     },
     "clean": {


### PR DESCRIPTION
## Summary by Sourcery

将伪 @ 提及的解析限制为仅在句首且只在第一个文本片段中进行，并在启用时使用缓存的昵称到 QQ 映射，以避免将行内文本误解析为提及。

Bug Fixes:
- 通过仅匹配第一个 Plain 片段中前导的提及模式，修复过度激进的伪 @ 提及解析问题。
- 将昵称到 QQ 的缓存受 `parse_at` 配置开关控制，在禁用提及解析时避免不必要的映射操作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restrict fake @-mention parsing to sentence heads and only the first text segment, using cached nickname-to-QQ mappings when enabled, to avoid mis-parsing inline text as mentions.

Bug Fixes:
- Fix over-aggressive fake @-mention parsing by matching only leading mention patterns in the first Plain segment.
- Guard nickname-to-QQ caching behind the parse_at configuration flag to avoid unnecessary mapping when mention parsing is disabled.

</details>