### PR TITLE
添加报错拦截并自定义消息返回原对话，不填则不返

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -115,6 +115,12 @@
                     "ignore"
                 ],
                 "default": "forward"
+            },
+            "custom_message": {
+                "description": "拦截时的自定义消息",
+                "hint": "当拦截报错或转发给管理员时，会在原对话中发送此消息。留空则不发送",
+                "type": "string",
+                "default": "抱歉，刚才遇到了一点问题，请稍后再试~"
             }
         }
     },


### PR DESCRIPTION
## Summary by Sourcery

添加可配置的错误拦截行为，在转发或阻止错误消息的同时，可选择性地向原始会话发送自定义回复。

新功能：
- 允许配置自定义错误消息，当在转发或阻止模式下拦截到错误时，将该消息发送回原始会话。

改进：
- 将上下文对象存储在 `OutputPlugin` 实例上，以便后续使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable error interception behavior that can optionally send a custom reply to the original conversation while forwarding or blocking error messages.

New Features:
- Allow configuring a custom error message that is sent back to the original conversation when errors are intercepted in forward or block modes.

Enhancements:
- Store the context object on the OutputPlugin instance for later use.

</details>