### PR TITLE
pref: 引入通用配置节点

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -2,7 +2,8 @@
 from __future__ import annotations
 
 import re
-from collections.abc import MutableMapping
+from collections.abc import Mapping, MutableMapping
+from types import MappingProxyType
 from typing import Any, get_type_hints
 
 from astrbot.api import logger
@@ -75,11 +76,11 @@ class ConfigNode:
             return
         object.__setattr__(self, key, value)
 
-    def raw_data(self) -> MutableMapping[str, Any]:
+    def raw_data(self) -> Mapping[str, Any]:
         """
-        获取底层配置 dict（实际引用，只读语义）
+        底层配置 dict 的只读视图
         """
-        return self._data
+        return MappingProxyType(self._data)
 
     def save_config(self) -> None:
         """


### PR DESCRIPTION
## Summary by Sourcery

引入通用、强类型的配置节点抽象，并将插件配置迁移为使用该抽象。

新功能：
- 添加可复用的 `ConfigNode` 基类，为配置字典提供基于 schema 的强类型访问，并支持嵌套节点。
- 在根配置节点上暴露 `save_config` 操作，用于持久化配置更改。

增强内容：
- 在所有插件配置中，用新的基于 `ConfigNode` 的配置模型替换之前的 `Section` 和 `TypedConfigFacade` 抽象。
- 放宽对必填字段的严格校验，改为在缺失配置字段时记录警告日志，并为嵌套配置节点添加惰性、带缓存的处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a generic, strongly-typed configuration node abstraction and migrate plugin configuration to use it.

New Features:
- Add a reusable ConfigNode base class that provides schema-based, strongly-typed access to configuration dictionaries with nested node support.
- Expose a save_config operation on the root configuration node to persist configuration changes.

Enhancements:
- Replace the previous Section and TypedConfigFacade abstractions with the new ConfigNode-based configuration model across plugin configs.
- Relax strict required-field validation in favor of warning logs for missing configuration fields and add lazy, cached handling of nested configuration nodes.

</details>