### PR TITLE
fix: ensure private session context when forwarding errors to admin

### DIFF
--- a/core/step/error.py
+++ b/core/step/error.py
@@ -42,6 +42,14 @@ class ErrorStep(BaseStep):
                 try:
                     session = copy.copy(ctx.event.session)
                     session.session_id = admin_id
+                    
+                    # 强制转换为私聊上下文，防止因复用群聊Session导致发送失败
+                    if hasattr(session, 'message_type'):
+                        session.message_type = 'private' 
+                    if hasattr(session, 'group_id'):
+                        session.group_id = None
+                    if hasattr(session, 'detail_type'): # onebot v12
+                         session.detail_type = 'private'
                     await context.send_message(session, chain)
                 except asyncio.CancelledError:
                     raise


### PR DESCRIPTION
When forwarding error messages to admins using the 'admin' option, the plugin reused the original session object. If the error occurred in a group chat, this caused the bot to attempt sending the forwarded message to a group with the admin's ID (which doesn't exist), resulting in failure (e.g. error code 110 on NTQQ).

This fix explicitly sets the session message type to 'private' and clears the group_id when forwarding to admins, ensuring the message is treated as a direct message.

## Summary by Sourcery

Bug Fixes:
- 通过强制将会话视为私聊上下文，修复了从群聊向管理员转发错误时出现的失败问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix failure when forwarding errors to admins from group chats by forcing the session to be treated as a private message context.

</details>