### PR TITLE
fix: 修复分段bug

### DIFF
--- a/core/step/block.py
+++ b/core/step/block.py
@@ -27,7 +27,7 @@ class BlockStep(BaseStep):
             return StepResult(abort=True, msg=f"已拦截流口水消息: {ctx.plain}")
 
     async def _block_words(self, ctx: OutContext) -> StepResult | None:
-        for word in self.cfg.ai_words:
+        for word in self.cfg.block_words:
             if word in ctx.plain:
                 ctx.event.set_result(ctx.event.plain_result(""))
                 return StepResult(


### PR DESCRIPTION
## Summary by Sourcery

修复文本拆分后处理逻辑，并纠正用于屏蔽消息的配置使用方式。

Bug 修复：
- 确保在处理 Plain 组件时，智能拆分始终遵循已配置的智能标志和拆分模式。
- 对每个分段中的所有 Plain 组件进行规范化：裁剪末尾空白，并从最后一个非空的 Plain 元素中移除末尾标点符号。
- 在过滤发出的消息时，使用正确配置的屏蔽词列表。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix text splitting post-processing and correct configuration usage for blocking messages.

Bug Fixes:
- Ensure smart splitting always respects the configured smart flag and split pattern when processing Plain components.
- Normalize all Plain components in each segment by trimming trailing whitespace and removing trailing punctuation from the last non-empty Plain element.
- Use the correct configured block word list when filtering outgoing messages.

</details>

错误修复：
- 确保智能拆分直接使用配置标志，并在后处理中正确处理所有 Plain 组件：去除结尾空白，并从每个分段中最后一个非空的 Plain 元素中移除结尾标点符号。
- 在过滤发出消息时，使用配置中正确的屏蔽词列表。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复文本拆分后处理逻辑，并纠正用于屏蔽消息的配置使用方式。

Bug 修复：
- 确保在处理 Plain 组件时，智能拆分始终遵循已配置的智能标志和拆分模式。
- 对每个分段中的所有 Plain 组件进行规范化：裁剪末尾空白，并从最后一个非空的 Plain 元素中移除末尾标点符号。
- 在过滤发出的消息时，使用正确配置的屏蔽词列表。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix text splitting post-processing and correct configuration usage for blocking messages.

Bug Fixes:
- Ensure smart splitting always respects the configured smart flag and split pattern when processing Plain components.
- Normalize all Plain components in each segment by trimming trailing whitespace and removing trailing punctuation from the last non-empty Plain element.
- Use the correct configured block word list when filtering outgoing messages.

</details>

</details>