### PR TITLE
perf(t2i): 引入异步保存避免阻塞

### DIFF
--- a/core/step/t2i.py
+++ b/core/step/t2i.py
@@ -1,5 +1,6 @@
 import shutil
 from pathlib import Path
+import asyncio
 
 from astrbot import logger
 from astrbot.core.message.components import Image, Plain
@@ -20,6 +21,9 @@ class T2IStep(BaseStep):
         self.style = None
 
     async def _load_style(self):
+        """
+        加载 pillowmd 样式
+        """
         try:
             import pillowmd
 
@@ -30,22 +34,25 @@ class T2IStep(BaseStep):
             logger.error(f"加载 pillowmd 失败: {e}")
 
     async def handle(self, ctx: OutContext) -> StepResult:
-        if (
-            isinstance(ctx.chain[-1], Plain)
-            and len(ctx.chain[-1].text) > self.cfg.threshold
-        ):
-            style = self.style or await self._load_style()
-            if style:
-                text = ctx.chain[-1].text
-                img = await style.AioRender(
-                    text=text,
-                    useImageUrl=True,
-                    autoPage=self.cfg.auto_page,
-                )
-                path = img.Save(self.image_cache_dir)
-                ctx.chain[-1] = Image.fromFileSystem(str(path))
-                return StepResult(msg=f"已将文本消息({text[:10]})转化为图片消息")
-        return StepResult()
+
+        # model.py 中定义的 OutContext 里，已经有一个 plain 字段了，
+        # 而且是直接把文本消息内容提取出来的字符串，所以这里直接用 ctx.plain 来判断比较明了简单了
+        if not ctx.plain or len(ctx.plain) <= self.cfg.threshold:
+            return StepResult()
+        style = self.style or await self._load_style()
+        if style:
+            text = ctx.plain
+            img = await style.AioRender(
+                text=text,
+                useImageUrl=True,
+                autoPage=self.cfg.auto_page,
+            )
+
+            #这个pillowmd库的Save方法是阻塞的，所以放到线程池里执行，避免阻塞主线程
+            path = await asyncio.to_thread(img.Save, self.image_cache_dir)
+            ctx.chain[-1] = Image.fromFileSystem(str(path))
+            return StepResult(msg=f"已将文本消息({text[:10]})转化为图片消息")
+    
 
     async def terminate(self):
         if self.cfg.clean_cache and self.image_cache_dir.exists():

--- a/core/step/t2i.py
+++ b/core/step/t2i.py
@@ -34,9 +34,6 @@ class T2IStep(BaseStep):
             logger.error(f"加载 pillowmd 失败: {e}")
 
     async def handle(self, ctx: OutContext) -> StepResult:
-
-        # model.py 中定义的 OutContext 里，已经有一个 plain 字段了，
-        # 而且是直接把文本消息内容提取出来的字符串，所以这里直接用 ctx.plain 来判断比较明了简单了
         if not ctx.plain or len(ctx.plain) <= self.cfg.threshold:
             return StepResult()
         style = self.style or await self._load_style()
@@ -48,14 +45,12 @@ class T2IStep(BaseStep):
                 autoPage=self.cfg.auto_page,
             )
 
-            #这个pillowmd库的Save方法是阻塞的，所以放到线程池里执行，避免阻塞主线程
             path = await asyncio.to_thread(img.Save, self.image_cache_dir)
             ctx.chain[-1] = Image.fromFileSystem(str(path))
             return StepResult(msg=f"已将文本消息({text[:10]})转化为图片消息")
         else:
             logger.error("无法加载 pillowmd 样式，无法执行文本转图片")
             return StepResult(ok=False, msg="pillowmd 样式加载失败")
-    
 
     async def terminate(self):
         if self.cfg.clean_cache and self.image_cache_dir.exists():

--- a/core/step/t2i.py
+++ b/core/step/t2i.py
@@ -52,6 +52,9 @@ class T2IStep(BaseStep):
             path = await asyncio.to_thread(img.Save, self.image_cache_dir)
             ctx.chain[-1] = Image.fromFileSystem(str(path))
             return StepResult(msg=f"已将文本消息({text[:10]})转化为图片消息")
+        else:
+            logger.error("无法加载 pillowmd 样式，无法执行文本转图片")
+            return StepResult(ok=False, msg="pillowmd 样式加载失败")
     
 
     async def terminate(self):


### PR DESCRIPTION
pillowmd库的Save方法是阻塞的,使用 asyncio.to_thread 执行阻塞的 Save 方法，避免阻塞主线程

## Summary by Sourcery

使用 pillowmd 异步将较长的纯文本消息渲染为图片，避免阻塞主事件循环。

Enhancements:
- 复用 `OutContext.plain` 进行阈值检查和文本提取，而不是检查消息链。
- 通过 `asyncio.to_thread` 将阻塞性的 pillowmd 图片保存调用卸载到后台线程，以防止阻塞事件循环。
- 为样式加载辅助函数添加简短的文档字符串，以明确其用途。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Render long plain text messages to images asynchronously using pillowmd without blocking the main event loop.

Enhancements:
- Reuse OutContext.plain for threshold checks and text extraction instead of inspecting the message chain.
- Offload blocking pillowmd image Save calls to a background thread via asyncio to_thread to prevent event loop blocking.
- Add a brief docstring for the style-loading helper to clarify its purpose.

</details>