### PR TITLE
feat: 接入运行时输出清洗与 TTS 标记保护

### DIFF
--- a/core/runtime_hook.py
+++ b/core/runtime_hook.py
@@ -1,17 +1,27 @@
 from __future__ import annotations
 
+import asyncio
+import copy
 from collections.abc import AsyncGenerator
+from dataclasses import dataclass
 from functools import wraps
 from typing import Any
 
 from astrbot.api import logger
-from astrbot.core.message.components import BaseMessageComponent
+from astrbot.core.message.components import BaseMessageComponent, Plain
 from astrbot.core.message.message_event_result import MessageChain
 from astrbot.core.platform.astr_message_event import AstrMessageEvent
 from astrbot.core.platform.platform import Platform
+from astrbot.core.platform.message_type import MessageType
 
 from .config import PluginConfig
 from .sanitize import collect_visible_text, replace_in_chain, sanitize_chain
+
+
+@dataclass(slots=True)
+class FilterDecision:
+    action: str = "pass"
+    matched_word: str | None = None
 
 
 def _iter_subclasses(cls: type) -> list[type]:
@@ -84,7 +94,12 @@ class RuntimeOutputHook:
             async def wrapped(event_self, message, *args, **kwargs):
                 chain = _normalize_message(message)
                 if chain is not None:
-                    if hook._filter_chain(chain, source=f"{cls.__name__}.send"):
+                    decision = await hook._filter_chain(
+                        chain,
+                        source=f"{cls.__name__}.send",
+                        session=getattr(event_self, "session", None),
+                    )
+                    if decision.action == "drop":
                         return None
                     message = chain
                 return await original(event_self, message, *args, **kwargs)
@@ -103,17 +118,24 @@ class RuntimeOutputHook:
                     return await original(event_self, generator, *args, **kwargs)
 
                 async def filtered_generator() -> AsyncGenerator[Any, None]:
+                    emitted_error_replacement = False
                     async for item in generator:
                         chain = _normalize_message(item)
                         if chain is None:
                             yield item
                             continue
 
-                        if hook._filter_chain(
+                        decision = await hook._filter_chain(
                             chain,
                             source=f"{cls.__name__}.send_streaming",
-                        ):
+                            session=getattr(event_self, "session", None),
+                        )
+                        if decision.action == "drop":
                             continue
+                        if decision.action == "replaced":
+                            if emitted_error_replacement:
+                                continue
+                            emitted_error_replacement = True
 
                         if not chain.chain:
                             continue
@@ -134,10 +156,12 @@ class RuntimeOutputHook:
             async def wrapped(platform_self, session, message_chain, *args, **kwargs):
                 chain = _normalize_message(message_chain)
                 if chain is not None:
-                    if hook._filter_chain(
+                    decision = await hook._filter_chain(
                         chain,
                         source=f"{cls.__name__}.send_by_session",
-                    ):
+                        session=session,
+                    )
+                    if decision.action == "drop":
                         return None
                     message_chain = chain
                 return await original(
@@ -152,9 +176,15 @@ class RuntimeOutputHook:
 
         self._patch(cls, "send_by_session", factory)
 
-    def _filter_chain(self, chain: MessageChain, source: str) -> bool:
+    async def _filter_chain(
+        self,
+        chain: MessageChain,
+        source: str,
+        *,
+        session=None,
+    ) -> FilterDecision:
         if not chain.chain:
-            return False
+            return FilterDecision(action="drop")
 
         before_count = len(chain.chain)
         before_plain = collect_visible_text(chain.chain)
@@ -174,21 +204,123 @@ class RuntimeOutputHook:
                 f"{before_plain!r} -> {plain!r}"
             )
 
+        error_word = self._match_error_keyword(plain)
+        if error_word:
+            await self._forward_error_if_needed(
+                plain,
+                session=session,
+                source=source,
+                keyword=error_word,
+            )
+            custom_msg = (self.config.error.custom_msg or "").strip()
+            if custom_msg:
+                chain.chain = MessageChain().message(custom_msg).chain
+                logger.warning(
+                    f"[outputpro:{source}] intercepted outbound error text by keyword: "
+                    f"{error_word}; replaced with custom_msg"
+                )
+                return FilterDecision(action="replaced", matched_word=error_word)
+
+            logger.warning(
+                f"[outputpro:{source}] intercepted outbound error text by keyword: "
+                f"{error_word}; dropped directly"
+            )
+            chain.chain.clear()
+            return FilterDecision(action="drop", matched_word=error_word)
+
         blocked_word = self._match_block_word(plain)
         if blocked_word:
             logger.info(
                 f"[outputpro:{source}] blocked outbound text by word: {blocked_word}"
             )
             chain.chain.clear()
-            return True
+            return FilterDecision(action="drop", matched_word=blocked_word)
 
-        return not chain.chain
+        return FilterDecision(action="drop" if not chain.chain else "pass")
+
+    async def _forward_error_if_needed(
+        self,
+        plain: str,
+        *,
+        session,
+        source: str,
+        keyword: str,
+    ) -> None:
+        forward_umo = (self.config.error.forward_umo or "").strip()
+        if not forward_umo or not plain:
+            return
+
+        context = getattr(self.config, "context", None)
+        if context is None:
+            return
+
+        chain = MessageChain([Plain(plain)])
+        if forward_umo == "admin":
+            admin_ids = [
+                str(admin_id).strip()
+                for admin_id in getattr(self.config, "admins_id", [])
+                if str(admin_id).strip()
+            ]
+            if not admin_ids:
+                logger.warning(
+                    f"[outputpro:{source}] hit runtime error keyword {keyword}, "
+                    "but no admins are configured for forwarding"
+                )
+                return
+            if session is None:
+                logger.warning(
+                    f"[outputpro:{source}] hit runtime error keyword {keyword}, "
+                    "but session context is missing so admin forwarding is skipped"
+                )
+                return
+
+            failed: list[str] = []
+            for admin_id in admin_ids:
+                try:
+                    admin_session = copy.copy(session)
+                    admin_session.session_id = admin_id
+                    admin_session.message_type = MessageType.FRIEND_MESSAGE
+                    await context.send_message(admin_session, chain)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    failed.append(admin_id)
+                    logger.warning(
+                        f"[outputpro:{source}] forward runtime error to admin "
+                        f"{admin_id} failed: {exc}"
+                    )
+
+            if failed:
+                logger.warning(
+                    f"[outputpro:{source}] runtime error keyword {keyword} forwarding "
+                    f"failed for admins: {','.join(failed)}"
+                )
+            return
+
+        try:
+            await context.send_message(forward_umo, chain)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                f"[outputpro:{source}] forward runtime error to {forward_umo} "
+                f"failed: {exc}"
+            )
 
     def _match_block_word(self, plain: str) -> str | None:
         if not plain:
             return None
 
         for word in self.config.block.block_words:
+            if word and word in plain:
+                return word
+        return None
+
+    def _match_error_keyword(self, plain: str) -> str | None:
+        if not plain:
+            return None
+
+        for word in self.config.error.keywords:
             if word and word in plain:
                 return word
         return None

--- a/core/runtime_hook.py
+++ b/core/runtime_hook.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from functools import wraps
+from typing import Any
+
+from astrbot.api import logger
+from astrbot.core.message.components import BaseMessageComponent
+from astrbot.core.message.message_event_result import MessageChain
+from astrbot.core.platform.astr_message_event import AstrMessageEvent
+from astrbot.core.platform.platform import Platform
+
+from .config import PluginConfig
+from .sanitize import collect_visible_text, replace_in_chain, sanitize_chain
+
+
+def _iter_subclasses(cls: type) -> list[type]:
+    seen: set[type] = set()
+    pending = [cls]
+    ordered: list[type] = []
+
+    while pending:
+        current = pending.pop(0)
+        if current in seen:
+            continue
+        seen.add(current)
+        ordered.append(current)
+        pending.extend(current.__subclasses__())
+
+    return ordered
+
+
+def _normalize_message(message: Any) -> MessageChain | None:
+    if message is None:
+        return None
+    if isinstance(message, MessageChain):
+        return message
+    if isinstance(message, str):
+        return MessageChain().message(message)
+    if isinstance(message, list) and all(
+        isinstance(component, BaseMessageComponent) for component in message
+    ):
+        return MessageChain(chain=message)
+    return None
+
+
+class RuntimeOutputHook:
+    def __init__(self, config: PluginConfig):
+        self.config = config
+        self._patched: list[tuple[type, str, Any]] = []
+        self._installed = False
+
+    def install(self) -> None:
+        for cls in _iter_subclasses(AstrMessageEvent)[1:]:
+            self._patch_event_send(cls)
+            self._patch_event_streaming(cls)
+
+        for cls in _iter_subclasses(Platform)[1:]:
+            self._patch_platform_send_by_session(cls)
+
+        self._installed = True
+
+    def uninstall(self) -> None:
+        for cls, attr, original in reversed(self._patched):
+            setattr(cls, attr, original)
+        self._patched.clear()
+        self._installed = False
+
+    def _patch(self, cls: type, attr: str, wrapper_factory) -> None:
+        original = getattr(cls, attr, None)
+        if original is None or getattr(original, "__outputpro_wrapped__", False):
+            return
+
+        wrapped = wrapper_factory(original)
+        wrapped.__outputpro_wrapped__ = True
+        self._patched.append((cls, attr, original))
+        setattr(cls, attr, wrapped)
+
+    def _patch_event_send(self, cls: type) -> None:
+        def factory(original):
+            hook = self
+
+            @wraps(original)
+            async def wrapped(event_self, message, *args, **kwargs):
+                chain = _normalize_message(message)
+                if chain is not None:
+                    if hook._filter_chain(chain, source=f"{cls.__name__}.send"):
+                        return None
+                    message = chain
+                return await original(event_self, message, *args, **kwargs)
+
+            return wrapped
+
+        self._patch(cls, "send", factory)
+
+    def _patch_event_streaming(self, cls: type) -> None:
+        def factory(original):
+            hook = self
+
+            @wraps(original)
+            async def wrapped(event_self, generator, *args, **kwargs):
+                if generator is None:
+                    return await original(event_self, generator, *args, **kwargs)
+
+                async def filtered_generator() -> AsyncGenerator[Any, None]:
+                    async for item in generator:
+                        chain = _normalize_message(item)
+                        if chain is None:
+                            yield item
+                            continue
+
+                        if hook._filter_chain(
+                            chain,
+                            source=f"{cls.__name__}.send_streaming",
+                        ):
+                            continue
+
+                        if not chain.chain:
+                            continue
+
+                        yield chain
+
+                return await original(event_self, filtered_generator(), *args, **kwargs)
+
+            return wrapped
+
+        self._patch(cls, "send_streaming", factory)
+
+    def _patch_platform_send_by_session(self, cls: type) -> None:
+        def factory(original):
+            hook = self
+
+            @wraps(original)
+            async def wrapped(platform_self, session, message_chain, *args, **kwargs):
+                chain = _normalize_message(message_chain)
+                if chain is not None:
+                    if hook._filter_chain(
+                        chain,
+                        source=f"{cls.__name__}.send_by_session",
+                    ):
+                        return None
+                    message_chain = chain
+                return await original(
+                    platform_self,
+                    session,
+                    message_chain,
+                    *args,
+                    **kwargs,
+                )
+
+            return wrapped
+
+        self._patch(cls, "send_by_session", factory)
+
+    def _filter_chain(self, chain: MessageChain, source: str) -> bool:
+        if not chain.chain:
+            return False
+
+        before_count = len(chain.chain)
+        before_plain = collect_visible_text(chain.chain)
+        clean_report = sanitize_chain(chain.chain, self.config.clean)
+        replace_changes = replace_in_chain(chain.chain, self.config.replace)
+        plain = collect_visible_text(chain.chain)
+
+        if clean_report.has_removed():
+            logger.debug(
+                f"[outputpro:{source}] cleaned outbound chain {before_count}->{len(chain.chain)}: "
+                f"{before_plain!r} -> {plain!r}"
+            )
+
+        if replace_changes:
+            logger.debug(
+                f"[outputpro:{source}] replaced outbound text: "
+                f"{before_plain!r} -> {plain!r}"
+            )
+
+        blocked_word = self._match_block_word(plain)
+        if blocked_word:
+            logger.info(
+                f"[outputpro:{source}] blocked outbound text by word: {blocked_word}"
+            )
+            chain.chain.clear()
+            return True
+
+        return not chain.chain
+
+    def _match_block_word(self, plain: str) -> str | None:
+        if not plain:
+            return None
+
+        for word in self.config.block.block_words:
+            if word and word in plain:
+                return word
+        return None

--- a/core/sanitize.py
+++ b/core/sanitize.py
@@ -157,7 +157,9 @@ def _remove_generic_tags(
 ) -> str:
     current = text
     for _ in range(8):
-        matches = [match.group("tag") for match in GENERIC_TAG_PATTERN.finditer(current)]
+        matches = [
+            match.group("tag") for match in GENERIC_TAG_PATTERN.finditer(current)
+        ]
         if not matches:
             break
         report.add_removed(label, matches)

--- a/core/sanitize.py
+++ b/core/sanitize.py
@@ -23,19 +23,15 @@ from .config import CleanConfig, ReplaceConfig
 
 SQUARE_BRACKET_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     ("square", re.compile(r"\[[^\[\]\r\n]{0,120}\]")),
-    ("square_cn", re.compile(r"【[^【】\r\n]{0,120}】")),
-    ("square_alt", re.compile(r"〔[^〔〕\r\n]{0,120}〕")),
+    ("square_cn", re.compile(r"\u3010[^\u3010\u3011\r\n]{0,120}\u3011")),
+    ("square_alt", re.compile(r"\u3014[^\u3014\u3015\r\n]{0,120}\u3015")),
 )
 
 PARENTHESIS_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     ("paren", re.compile(r"\([^()\r\n]{0,120}\)")),
-    ("paren_cn", re.compile(r"（[^（）\r\n]{0,120}）")),
+    ("paren_cn", re.compile(r"\uFF08[^\uFF08\uFF09\r\n]{0,120}\uFF09")),
     ("brace", re.compile(r"\{[^{}\r\n]{0,120}\}")),
-    ("brace_cn", re.compile(r"｛[^｛｝\r\n]{0,120}｝")),
-    ("quote_cn", re.compile(r"「[^「」\r\n]{0,120}」")),
-    ("quote_cn_alt", re.compile(r"『[^『』\r\n]{0,120}』")),
-    ("angle_cn", re.compile(r"《[^《》\r\n]{0,120}》")),
-    ("angle_cn_alt", re.compile(r"〈[^〈〉\r\n]{0,120}〉")),
+    ("brace_cn", re.compile(r"\uFF5B[^\uFF5B\uFF5D\r\n]{0,120}\uFF5D")),
 )
 
 GENERIC_TAG_PATTERN = re.compile(
@@ -44,6 +40,10 @@ GENERIC_TAG_PATTERN = re.compile(
     r"(?![0-9A-Za-z])"
 )
 TTS_SPEED_TAG_PATTERN = re.compile(r"<#\s*\d+(?:\.\d{1,2})?\s*#>")
+ASCII_WRAPPED_TAG_RE = re.compile(
+    r"(?:EMO(?:\s*[:：-]\s*[A-Za-z_-]{1,24})?|[A-Za-z][A-Za-z0-9_-]{0,23})",
+    re.IGNORECASE,
+)
 
 MULTI_SPACE_RE = re.compile(r"[ \t]{2,}")
 LINE_SPACE_RE = re.compile(r"[ \t]*\n[ \t]*")
@@ -90,6 +90,34 @@ def _should_apply_cosmetic_cleanup(text: str, cfg: CleanConfig) -> bool:
     return len(text) < cfg.text_threshold
 
 
+def _extract_wrapped_inner_text(wrapped: str) -> str:
+    if len(wrapped) < 2:
+        return wrapped.strip()
+    return wrapped[1:-1].strip()
+
+
+def _looks_like_wrapped_markup(inner: str) -> bool:
+    if not inner or len(inner) > 24:
+        return False
+
+    if any(ch in inner for ch in "\r\n\t"):
+        return False
+
+    if inner.isdigit():
+        return False
+
+    if re.search(r"[\u4e00-\u9fff]", inner):
+        return False
+
+    if re.search(r"[，。！？；：,.!?;:/\\\\]", inner):
+        return False
+
+    if " " in inner:
+        return False
+
+    return bool(ASCII_WRAPPED_TAG_RE.fullmatch(inner))
+
+
 def _remove_patterns(
     text: str,
     patterns: tuple[tuple[str, re.Pattern[str]], ...],
@@ -100,12 +128,23 @@ def _remove_patterns(
     for _ in range(8):
         changed = False
         for _, pattern in patterns:
-            matches = pattern.findall(current)
-            if not matches:
+            removed: list[str] = []
+
+            def _replace(match: re.Match[str]) -> str:
+                wrapped = match.group(0)
+                if not _looks_like_wrapped_markup(_extract_wrapped_inner_text(wrapped)):
+                    return wrapped
+                removed.append(wrapped)
+                return ""
+
+            updated = pattern.sub(_replace, current)
+            if not removed:
                 continue
-            report.add_removed(label, matches)
-            current = pattern.sub("", current)
+
+            report.add_removed(label, removed)
+            current = updated
             changed = True
+
         if not changed:
             break
     return current

--- a/core/sanitize.py
+++ b/core/sanitize.py
@@ -1,0 +1,431 @@
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from dataclasses import dataclass, field
+
+import emoji
+
+from astrbot.core.message.components import (
+    BaseMessageComponent,
+    Location,
+    Music,
+    Node,
+    Nodes,
+    Plain,
+    Record,
+    Reply,
+    Share,
+    Unknown,
+)
+
+from .config import CleanConfig, ReplaceConfig
+
+SQUARE_BRACKET_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("square", re.compile(r"\[[^\[\]\r\n]{0,120}\]")),
+    ("square_cn", re.compile(r"【[^【】\r\n]{0,120}】")),
+    ("square_alt", re.compile(r"〔[^〔〕\r\n]{0,120}〕")),
+)
+
+PARENTHESIS_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("paren", re.compile(r"\([^()\r\n]{0,120}\)")),
+    ("paren_cn", re.compile(r"（[^（）\r\n]{0,120}）")),
+    ("brace", re.compile(r"\{[^{}\r\n]{0,120}\}")),
+    ("brace_cn", re.compile(r"｛[^｛｝\r\n]{0,120}｝")),
+    ("quote_cn", re.compile(r"「[^「」\r\n]{0,120}」")),
+    ("quote_cn_alt", re.compile(r"『[^『』\r\n]{0,120}』")),
+    ("angle_cn", re.compile(r"《[^《》\r\n]{0,120}》")),
+    ("angle_cn_alt", re.compile(r"〈[^〈〉\r\n]{0,120}〉")),
+)
+
+GENERIC_TAG_PATTERN = re.compile(
+    r"(?<![0-9A-Za-z])"
+    r"(?P<tag>(?P<delim>(?P<sym>[&@#~|=+%^])(?P=sym){1,2})(?P<body>[^\r\n]{0,40}?)(?P=delim))"
+    r"(?![0-9A-Za-z])"
+)
+TTS_SPEED_TAG_PATTERN = re.compile(r"<#\s*\d+(?:\.\d{1,2})?\s*#>")
+
+MULTI_SPACE_RE = re.compile(r"[ \t]{2,}")
+LINE_SPACE_RE = re.compile(r"[ \t]*\n[ \t]*")
+
+TEXT_ATTRS: dict[type[BaseMessageComponent], tuple[str, ...]] = {
+    Plain: ("text",),
+    Unknown: ("text",),
+    Record: ("text",),
+    Reply: ("text", "message_str"),
+    Share: ("title", "content"),
+    Music: ("title", "content"),
+    Location: ("title", "content"),
+}
+
+
+@dataclass(slots=True)
+class TextProcessReport:
+    removed: dict[str, list[str]] = field(
+        default_factory=lambda: defaultdict(list),
+    )
+    replacements: list[tuple[str, str]] = field(default_factory=list)
+
+    def add_removed(self, label: str, values: list[str]) -> None:
+        if values:
+            self.removed[label].extend(values)
+
+    def extend(self, other: "TextProcessReport") -> None:
+        for label, values in other.removed.items():
+            self.removed[label].extend(values)
+        self.replacements.extend(other.replacements)
+
+    def has_removed(self) -> bool:
+        return any(self.removed.values())
+
+
+def _append_unique(target: list[tuple[str, str]], pair: tuple[str, str]) -> None:
+    if pair not in target:
+        target.append(pair)
+
+
+def _should_apply_cosmetic_cleanup(text: str, cfg: CleanConfig) -> bool:
+    if cfg.text_threshold <= 0:
+        return False
+    return len(text) < cfg.text_threshold
+
+
+def _remove_patterns(
+    text: str,
+    patterns: tuple[tuple[str, re.Pattern[str]], ...],
+    label: str,
+    report: TextProcessReport,
+) -> str:
+    current = text
+    for _ in range(8):
+        changed = False
+        for _, pattern in patterns:
+            matches = pattern.findall(current)
+            if not matches:
+                continue
+            report.add_removed(label, matches)
+            current = pattern.sub("", current)
+            changed = True
+        if not changed:
+            break
+    return current
+
+
+def _remove_generic_tags(
+    text: str,
+    label: str,
+    report: TextProcessReport,
+) -> str:
+    current = text
+    for _ in range(8):
+        matches = [match.group("tag") for match in GENERIC_TAG_PATTERN.finditer(current)]
+        if not matches:
+            break
+        report.add_removed(label, matches)
+        current = GENERIC_TAG_PATTERN.sub("", current)
+    return current
+
+
+def _tidy_spacing(text: str) -> str:
+    text = LINE_SPACE_RE.sub("\n", text)
+    return MULTI_SPACE_RE.sub(" ", text)
+
+
+def clean_text(
+    text: str,
+    cfg: CleanConfig,
+    *,
+    emotion_tag: bool | None = None,
+) -> tuple[str, TextProcessReport]:
+    report = TextProcessReport()
+    if not text:
+        return text, report
+
+    cleaned = text
+    apply_emotion_tag = cfg.emotion_tag if emotion_tag is None else emotion_tag
+
+    if cfg.bracket:
+        cleaned = _remove_patterns(
+            cleaned,
+            SQUARE_BRACKET_PATTERNS,
+            "bracket_content",
+            report,
+        )
+
+    if cfg.parenthesis:
+        cleaned = _remove_patterns(
+            cleaned,
+            PARENTHESIS_PATTERNS,
+            "parenthetical_content",
+            report,
+        )
+
+    if apply_emotion_tag:
+        cleaned = _remove_generic_tags(cleaned, "wrapped_tag", report)
+        speed_tags = TTS_SPEED_TAG_PATTERN.findall(cleaned)
+        if speed_tags:
+            report.add_removed("tts_speed_tag", speed_tags)
+            cleaned = TTS_SPEED_TAG_PATTERN.sub("", cleaned)
+
+    if cleaned != text:
+        cleaned = _tidy_spacing(cleaned)
+
+    if _should_apply_cosmetic_cleanup(cleaned, cfg):
+        if cfg.emoji:
+            emojis = [char for char in cleaned if char in emoji.EMOJI_DATA]
+            if emojis:
+                report.add_removed("emoji", emojis)
+                cleaned = emoji.replace_emoji(cleaned, replace="")
+
+        if cfg.lead:
+            for prefix in cfg.lead:
+                if prefix and cleaned.startswith(prefix):
+                    report.add_removed("lead", [prefix])
+                    cleaned = cleaned[len(prefix) :]
+                    break
+
+        if cfg.tail:
+            for suffix in cfg.tail:
+                if suffix and cleaned.endswith(suffix):
+                    report.add_removed("tail", [suffix])
+                    cleaned = cleaned[: -len(suffix)]
+                    break
+
+        if cfg.punctuation:
+            matches = re.findall(cfg.punctuation, cleaned)
+            if matches:
+                report.add_removed("punctuation", matches)
+                cleaned = re.sub(cfg.punctuation, "", cleaned)
+
+    return cleaned, report
+
+
+def _iter_text_attrs(component: BaseMessageComponent):
+    for component_type, attrs in TEXT_ATTRS.items():
+        if isinstance(component, component_type):
+            for attr in attrs:
+                value = getattr(component, attr, None)
+                if isinstance(value, str) and value:
+                    yield attr, value
+            break
+
+
+def _prune_empty_components(chain: list[BaseMessageComponent]) -> None:
+    kept: list[BaseMessageComponent] = []
+    for component in chain:
+        if isinstance(component, Node):
+            _prune_empty_components(component.content)
+            if not component.content:
+                continue
+        elif isinstance(component, Nodes):
+            for node in component.nodes:
+                _prune_empty_components(node.content)
+            component.nodes = [node for node in component.nodes if node.content]
+            if not component.nodes:
+                continue
+        elif isinstance(component, Reply) and component.chain:
+            _prune_empty_components(component.chain)
+
+        if isinstance(component, (Plain, Unknown)):
+            text = getattr(component, "text", "")
+            if not text or not text.strip():
+                continue
+
+        kept.append(component)
+
+    chain[:] = kept
+
+
+def sanitize_chain(
+    chain: list[BaseMessageComponent],
+    cfg: CleanConfig,
+    *,
+    emotion_tag: bool | None = None,
+) -> TextProcessReport:
+    report = TextProcessReport()
+    for component in chain:
+        if isinstance(component, Node):
+            report.extend(
+                sanitize_chain(component.content, cfg, emotion_tag=emotion_tag)
+            )
+        elif isinstance(component, Nodes):
+            for node in component.nodes:
+                report.extend(
+                    sanitize_chain(node.content, cfg, emotion_tag=emotion_tag)
+                )
+        elif isinstance(component, Reply) and component.chain:
+            report.extend(sanitize_chain(component.chain, cfg, emotion_tag=emotion_tag))
+
+        for attr, value in _iter_text_attrs(component):
+            cleaned, local_report = clean_text(
+                value,
+                cfg,
+                emotion_tag=emotion_tag,
+            )
+            if cleaned != value:
+                setattr(component, attr, cleaned)
+            report.extend(local_report)
+
+    _prune_empty_components(chain)
+    return report
+
+
+def _unescape_replace_text(value: str) -> str:
+    return (
+        value.replace("\\n", "\n")
+        .replace("\\r", "\r")
+        .replace("\\t", "\t")
+        .replace("\\s", " ")
+        .replace("\\\\", "\\")
+    )
+
+
+def build_replace_pairs(cfg: ReplaceConfig) -> list[tuple[str, str]]:
+    pairs: list[tuple[str, str]] = []
+    for item in cfg.words:
+        if not item or not item.strip():
+            continue
+
+        raw_old, sep, raw_new = item.partition(" ")
+        old = _unescape_replace_text(raw_old)
+        if not old:
+            continue
+
+        if not sep:
+            new = cfg.default_new_word * len(old)
+        else:
+            new = _unescape_replace_text(raw_new)
+
+        pairs.append((old, new))
+
+    return pairs
+
+
+def replace_text(
+    text: str,
+    cfg: ReplaceConfig,
+) -> tuple[str, list[tuple[str, str]]]:
+    if not text:
+        return text, []
+
+    pairs = build_replace_pairs(cfg)
+    if not pairs:
+        return text, []
+
+    updated = text
+    changes: list[tuple[str, str]] = []
+    for old, new in pairs:
+        if old in updated:
+            updated = updated.replace(old, new)
+            _append_unique(changes, (repr(old), repr(new)))
+
+    return updated, changes
+
+
+def replace_in_chain(
+    chain: list[BaseMessageComponent],
+    cfg: ReplaceConfig,
+) -> list[tuple[str, str]]:
+    pairs = build_replace_pairs(cfg)
+    if not pairs:
+        return []
+
+    changes: list[tuple[str, str]] = []
+    for component in chain:
+        if isinstance(component, Node):
+            for pair in replace_in_chain(component.content, cfg):
+                _append_unique(changes, pair)
+        elif isinstance(component, Nodes):
+            for node in component.nodes:
+                for pair in replace_in_chain(node.content, cfg):
+                    _append_unique(changes, pair)
+        elif isinstance(component, Reply) and component.chain:
+            for pair in replace_in_chain(component.chain, cfg):
+                _append_unique(changes, pair)
+
+        for attr, value in _iter_text_attrs(component):
+            updated = value
+            for old, new in pairs:
+                if old in updated:
+                    updated = updated.replace(old, new)
+                    _append_unique(changes, (repr(old), repr(new)))
+            if updated != value:
+                setattr(component, attr, updated)
+
+    _prune_empty_components(chain)
+    return changes
+
+
+def transform_text_in_chain(
+    chain: list[BaseMessageComponent],
+    transform,
+) -> list[tuple[str, str]]:
+    changes: list[tuple[str, str]] = []
+    for component in chain:
+        if isinstance(component, Node):
+            for pair in transform_text_in_chain(component.content, transform):
+                _append_unique(changes, pair)
+        elif isinstance(component, Nodes):
+            for node in component.nodes:
+                for pair in transform_text_in_chain(node.content, transform):
+                    _append_unique(changes, pair)
+        elif isinstance(component, Reply) and component.chain:
+            for pair in transform_text_in_chain(component.chain, transform):
+                _append_unique(changes, pair)
+
+        for attr, value in _iter_text_attrs(component):
+            updated = transform(value)
+            if updated == value:
+                continue
+            setattr(component, attr, updated)
+            _append_unique(changes, (value, updated))
+
+    _prune_empty_components(chain)
+    return changes
+
+
+def collect_visible_text(chain: list[BaseMessageComponent]) -> str:
+    texts: list[str] = []
+    for component in chain:
+        if isinstance(component, Node):
+            nested = collect_visible_text(component.content)
+            if nested:
+                texts.append(nested)
+            continue
+
+        if isinstance(component, Nodes):
+            for node in component.nodes:
+                nested = collect_visible_text(node.content)
+                if nested:
+                    texts.append(nested)
+            continue
+
+        if isinstance(component, Reply) and component.chain:
+            nested = collect_visible_text(component.chain)
+            if nested:
+                texts.append(nested)
+
+        for _, value in _iter_text_attrs(component):
+            value = value.strip()
+            if value:
+                texts.append(value)
+
+    return " ".join(texts)
+
+
+def format_removed_summary(report: TextProcessReport) -> str:
+    if not report.has_removed():
+        return ""
+
+    parts: list[str] = []
+    for label, items in report.removed.items():
+        unique_items = list(dict.fromkeys(items))
+        if len(unique_items) == 1:
+            parts.append(f"{label}: {unique_items[0]}")
+            continue
+
+        preview = " / ".join(unique_items[:3])
+        suffix = f" (+{len(unique_items) - 3})" if len(unique_items) > 3 else ""
+        parts.append(f"{label}: {preview}{suffix}")
+
+    return "cleaned -> " + "; ".join(parts)

--- a/core/step/clean.py
+++ b/core/step/clean.py
@@ -1,12 +1,6 @@
-import re
-from collections import defaultdict
-
-import emoji
-
-from astrbot.core.message.components import Plain
-
 from ..config import PluginConfig
 from ..model import OutContext, StepName, StepResult
+from ..sanitize import collect_visible_text, format_removed_summary, sanitize_chain
 from .base import BaseStep
 
 
@@ -18,82 +12,6 @@ class CleanStep(BaseStep):
         self.cfg = config.clean
 
     async def handle(self, ctx: OutContext) -> StepResult:
-        removed: dict[str, list[str]] = defaultdict(list)
-
-        for seg in ctx.chain:
-            if not isinstance(seg, Plain):
-                continue
-
-            if len(seg.text) >= self.cfg.text_threshold:
-                continue
-
-            # 中括号
-            if self.cfg.bracket:
-                matches = re.findall(r"\[.*?\]", seg.text)
-                if matches:
-                    removed["中括号内容"].extend(matches)
-                    seg.text = re.sub(r"\[.*?\]", "", seg.text)
-
-            # 圆括号
-            if self.cfg.parenthesis:
-                matches = re.findall(r"[（(].*?[）)]", seg.text)
-                if matches:
-                    removed["圆括号内容"].extend(matches)
-                    seg.text = re.sub(r"[（(].*?[）)]", "", seg.text)
-
-            # 情绪标签
-            if self.cfg.emotion_tag:
-                matches = re.findall(r"&&.*?&&", seg.text)
-                if matches:
-                    removed["情绪标签"].extend(matches)
-                    seg.text = re.sub(r"&&.*?&&", "", seg.text)
-
-            # Emoji
-            if self.cfg.emoji:
-                emojis = [c for c in seg.text if c in emoji.EMOJI_DATA]
-                if emojis:
-                    removed["Emoji"].extend(emojis)
-                    seg.text = emoji.replace_emoji(seg.text, replace="")
-
-            # 前缀
-            if self.cfg.lead:
-                for s in self.cfg.lead:
-                    if seg.text.startswith(s):
-                        removed["前缀"].append(s)
-                        seg.text = seg.text[len(s) :]
-                        break
-
-            # 后缀
-            if self.cfg.tail:
-                for s in self.cfg.tail:
-                    if seg.text.endswith(s):
-                        removed["后缀"].append(s)
-                        seg.text = seg.text[: -len(s)]
-                        break
-
-            # 标点
-            if self.cfg.punctuation:
-                matches = re.findall(self.cfg.punctuation, seg.text)
-                if matches:
-                    removed["标点字符"].extend(matches)
-                    seg.text = re.sub(self.cfg.punctuation, "", seg.text)
-
-        return StepResult(msg=self._build_msg(removed))
-
-    def _build_msg(self, removed: dict[str, list[str]]) -> str:
-        """消息构建（记录删了什么）"""
-        if not removed:
-            return ""
-
-        parts: list[str] = []
-
-        for k, items in removed.items():
-            uniq = list(dict.fromkeys(items))  # 去重但保序
-            if len(uniq) == 1:
-                parts.append(f"{k}: {uniq[0]}")
-            else:
-                preview = "、".join(uniq[:3])
-                more = f" 等{len(uniq)}项" if len(uniq) > 3 else ""
-                parts.append(f"{k}: {preview}{more}")
-
-        return "文本清理：" + "；".join(parts)
+        report = sanitize_chain(ctx.chain, self.cfg)
+        ctx.plain = collect_visible_text(ctx.chain)
+        return StepResult(msg=format_removed_summary(report))

--- a/core/step/replace.py
+++ b/core/step/replace.py
@@ -16,9 +16,7 @@ class ReplaceStep(BaseStep):
         ctx.plain = collect_visible_text(ctx.chain)
 
         if changes:
-            msg = "replaced ->\n" + "\n".join(
-                f"{old} -> {new}" for old, new in changes
-            )
+            msg = "replaced ->\n" + "\n".join(f"{old} -> {new}" for old, new in changes)
             return StepResult(msg=msg)
 
         return StepResult()

--- a/core/step/replace.py
+++ b/core/step/replace.py
@@ -1,7 +1,6 @@
-from astrbot.core.message.components import Plain
-
 from ..config import PluginConfig
 from ..model import OutContext, StepName, StepResult
+from ..sanitize import collect_visible_text, replace_in_chain
 from .base import BaseStep
 
 
@@ -12,41 +11,14 @@ class ReplaceStep(BaseStep):
         super().__init__(config)
         self.cfg = config.replace
 
-    def _unescape(self, s: str) -> str:
-        """
-        简单转义处理：将 \\n, \\r, \\t, \\s 等转换为实际字符
-        """
-        return (
-            s.replace("\\n", "\n")  # 换行符
-            .replace("\\r", "\r")  # 回车符
-            .replace("\\t", "\t")  # 制表符
-            .replace("\\s", " ")  # 空格
-            .replace("\\\\", "\\")  # 反斜杠本身（放最后）
-        )
-
     async def handle(self, ctx: OutContext) -> StepResult:
-        changes: list[tuple[str, str]] = []
-
-        for seg in ctx.chain:
-            if isinstance(seg, Plain):
-                for word in self.cfg.words:
-                    if not word.strip():
-                        continue
-
-                    raw_old, sep, raw_new = word.partition(" ")
-                    old = self._unescape(raw_old)
-
-                    if not sep:
-                        new = self.cfg.default_new_word * len(old)
-                    else:
-                        new = self._unescape(raw_new)
-
-                    if old in seg.text:
-                        seg.text = seg.text.replace(old, new)
-                        changes.append((repr(old), repr(new)))
+        changes = replace_in_chain(ctx.chain, self.cfg)
+        ctx.plain = collect_visible_text(ctx.chain)
 
         if changes:
-            msg = "已替换：\n" + "\n".join(f"{old} -> {new}" for old, new in changes)
+            msg = "replaced ->\n" + "\n".join(
+                f"{old} -> {new}" for old, new in changes
+            )
             return StepResult(msg=msg)
 
         return StepResult()

--- a/main.py
+++ b/main.py
@@ -64,7 +64,9 @@ class OutputPlugin(Star):
             event,
             tts_instance,
         )
-        self._set_event_extra(event, "_outputpro_preserve_emotion_tag", preserve_emotion_tag)
+        self._set_event_extra(
+            event, "_outputpro_preserve_emotion_tag", preserve_emotion_tag
+        )
         self._set_event_extra(event, "_outputpro_preserve_reason", preserve_reason)
 
         result_chain = getattr(response, "result_chain", None)
@@ -84,7 +86,9 @@ class OutputPlugin(Star):
                 if tts_instance is not None:
                     transform_text_in_chain(
                         chain,
-                        lambda value: self._sanitize_with_tts_plugin(tts_instance, value),
+                        lambda value: self._sanitize_with_tts_plugin(
+                            tts_instance, value
+                        ),
                     )
                 sanitize_chain(
                     chain,
@@ -202,7 +206,9 @@ class OutputPlugin(Star):
 
         return False
 
-    def _resolve_emotion_tag_policy(self, event: AstrMessageEvent, tts_instance) -> tuple[bool, str]:
+    def _resolve_emotion_tag_policy(
+        self, event: AstrMessageEvent, tts_instance
+    ) -> tuple[bool, str]:
         marker_mode = self._get_tts_output_marker_mode(event)
         if marker_mode == TTS_OUTPUT_MARKER_MODE_PRESERVE:
             return True, "tts_marker_mode_preserve"
@@ -343,7 +349,9 @@ class OutputPlugin(Star):
         )
         return self._restore_tts_controls(cleaned_text, placeholders)
 
-    def _protect_tts_controls(self, tts_instance, text: str) -> tuple[str, dict[str, str]]:
+    def _protect_tts_controls(
+        self, tts_instance, text: str
+    ) -> tuple[str, dict[str, str]]:
         placeholders: dict[str, str] = {}
         counter = 0
 
@@ -354,7 +362,9 @@ class OutputPlugin(Star):
             placeholders[token] = raw
             return token
 
-        protected_text = TTS_PAUSE_TAG_RE.sub(lambda match: _stash(match.group(0)), text)
+        protected_text = TTS_PAUSE_TAG_RE.sub(
+            lambda match: _stash(match.group(0)), text
+        )
         expressive_tags = self._get_tts_expressive_tags(tts_instance)
         if expressive_tags:
             voice_tag_re = re.compile(

--- a/main.py
+++ b/main.py
@@ -1,3 +1,6 @@
+import importlib
+import re
+
 from astrbot.api import logger
 from astrbot.api.event import filter
 from astrbot.api.provider import LLMResponse
@@ -23,6 +26,7 @@ TTS_EMOTION_ROUTER_ROOT = "astrbot_plugin_tts_emotion_router"
 TTS_OUTPUT_MARKER_MODE_EXTRA = "_tts_emotion_router_output_marker_mode"
 TTS_OUTPUT_MARKER_MODE_PRESERVE = "preserve_for_tts"
 TTS_OUTPUT_MARKER_MODE_STRIP = "strip_visible"
+TTS_PAUSE_TAG_RE = re.compile(r"<#\s*\d+(?:\.\d{1,2})?\s*#>")
 
 
 class OutputPlugin(Star):
@@ -65,33 +69,28 @@ class OutputPlugin(Star):
 
         result_chain = getattr(response, "result_chain", None)
         chain = getattr(result_chain, "chain", None)
-        if preserve_emotion_tag:
-            completion_text = getattr(response, "completion_text", None)
-            visible_text = collect_visible_text(chain) if chain else ""
-            if not visible_text and isinstance(completion_text, str):
-                visible_text = completion_text
-
-            logger.debug(
-                "[outputpro:on_llm_response] preserve_emotion_tag=%s reason=%s raw=%r",
-                preserve_emotion_tag,
-                preserve_reason,
-                visible_text,
-            )
-            self._block_llm_response_if_needed(response, visible_text)
-            return
 
         if chain:
             before_count = len(chain)
-            if tts_instance is not None:
+            if preserve_emotion_tag:
                 transform_text_in_chain(
                     chain,
-                    lambda value: self._sanitize_with_tts_plugin(tts_instance, value),
+                    lambda value: self._sanitize_for_tts_preserve_mode(
+                        tts_instance,
+                        value,
+                    ),
                 )
-            sanitize_chain(
-                chain,
-                self.cfg.clean,
-                emotion_tag=True,
-            )
+            else:
+                if tts_instance is not None:
+                    transform_text_in_chain(
+                        chain,
+                        lambda value: self._sanitize_with_tts_plugin(tts_instance, value),
+                    )
+                sanitize_chain(
+                    chain,
+                    self.cfg.clean,
+                    emotion_tag=True,
+                )
             replace_in_chain(chain, self.cfg.replace)
 
             plain = collect_visible_text(chain)
@@ -108,16 +107,24 @@ class OutputPlugin(Star):
 
         completion_text = getattr(response, "completion_text", None)
         updated_text = completion_text if isinstance(completion_text, str) else ""
-        if updated_text and tts_instance is not None:
+        if updated_text and preserve_emotion_tag:
+            updated_text = self._sanitize_for_tts_preserve_mode(
+                tts_instance,
+                updated_text,
+            )
+        elif updated_text and tts_instance is not None:
             updated_text = self._sanitize_with_tts_plugin(
                 tts_instance,
                 updated_text,
             )
-        cleaned_text, _ = clean_text(
-            updated_text,
-            self.cfg.clean,
-            emotion_tag=True,
-        )
+        if preserve_emotion_tag:
+            cleaned_text = updated_text
+        else:
+            cleaned_text, _ = clean_text(
+                updated_text,
+                self.cfg.clean,
+                emotion_tag=True,
+            )
         cleaned_text, _ = replace_text(cleaned_text, self.cfg.replace)
         if isinstance(completion_text, str) and cleaned_text != completion_text:
             response.completion_text = cleaned_text
@@ -326,6 +333,68 @@ class OutputPlugin(Star):
                 exc_info=True,
             )
             return text
+
+    def _sanitize_for_tts_preserve_mode(self, tts_instance, text: str) -> str:
+        protected_text, placeholders = self._protect_tts_controls(tts_instance, text)
+        cleaned_text, _ = clean_text(
+            protected_text,
+            self.cfg.clean,
+            emotion_tag=True,
+        )
+        return self._restore_tts_controls(cleaned_text, placeholders)
+
+    def _protect_tts_controls(self, tts_instance, text: str) -> tuple[str, dict[str, str]]:
+        placeholders: dict[str, str] = {}
+        counter = 0
+
+        def _stash(raw: str) -> str:
+            nonlocal counter
+            token = f"__OUTPUTPRO_TTS_KEEP_{counter}__"
+            counter += 1
+            placeholders[token] = raw
+            return token
+
+        protected_text = TTS_PAUSE_TAG_RE.sub(lambda match: _stash(match.group(0)), text)
+        expressive_tags = self._get_tts_expressive_tags(tts_instance)
+        if expressive_tags:
+            voice_tag_re = re.compile(
+                rf"\((?:{'|'.join(re.escape(tag) for tag in expressive_tags)})\)",
+                re.IGNORECASE,
+            )
+            protected_text = voice_tag_re.sub(
+                lambda match: _stash(match.group(0)),
+                protected_text,
+            )
+
+        return protected_text, placeholders
+
+    @staticmethod
+    def _restore_tts_controls(text: str, placeholders: dict[str, str]) -> str:
+        restored = text
+        for token, raw in placeholders.items():
+            restored = restored.replace(token, raw)
+        return restored
+
+    @staticmethod
+    def _get_tts_expressive_tags(tts_instance) -> tuple[str, ...]:
+        if tts_instance is None:
+            return ()
+
+        try:
+            module = importlib.import_module(tts_instance.__class__.__module__)
+            tags = getattr(module, "MINIMAX_EXPRESSIVE_TAGS", None)
+            if isinstance(tags, (list, tuple, set)):
+                normalized = tuple(
+                    str(tag).strip().lower() for tag in tags if str(tag).strip()
+                )
+                return normalized
+        except Exception:
+            logger.debug(
+                "[outputpro:on_llm_response] failed to inspect TTS expressive tags",
+                exc_info=True,
+            )
+
+        return ()
 
     @staticmethod
     def _set_event_extra(event: AstrMessageEvent, key: str, value) -> None:

--- a/main.py
+++ b/main.py
@@ -1,4 +1,6 @@
+from astrbot.api import logger
 from astrbot.api.event import filter
+from astrbot.api.provider import LLMResponse
 from astrbot.api.star import Context, Star
 from astrbot.core import AstrBotConfig
 from astrbot.core.platform.astr_message_event import AstrMessageEvent
@@ -6,6 +8,21 @@ from astrbot.core.platform.astr_message_event import AstrMessageEvent
 from .core.config import PluginConfig
 from .core.model import OutContext, StateManager, StepName
 from .core.pipeline import Pipeline
+from .core.runtime_hook import RuntimeOutputHook
+from .core.sanitize import (
+    collect_visible_text,
+    clean_text,
+    replace_in_chain,
+    replace_text,
+    sanitize_chain,
+    transform_text_in_chain,
+)
+
+TTS_EMOTION_ROUTER_NAME = "TTS 情绪路由"
+TTS_EMOTION_ROUTER_ROOT = "astrbot_plugin_tts_emotion_router"
+TTS_OUTPUT_MARKER_MODE_EXTRA = "_tts_emotion_router_output_marker_mode"
+TTS_OUTPUT_MARKER_MODE_PRESERVE = "preserve_for_tts"
+TTS_OUTPUT_MARKER_MODE_STRIP = "strip_visible"
 
 
 class OutputPlugin(Star):
@@ -13,12 +30,109 @@ class OutputPlugin(Star):
         super().__init__(context)
         self.cfg = PluginConfig(config, context)
         self.pipeline = Pipeline(self.cfg)
+        self.runtime_hook = RuntimeOutputHook(self.cfg)
 
     async def initialize(self):
         await self.pipeline.initialize()
+        self.runtime_hook.install()
 
     async def terminate(self):
+        self.runtime_hook.uninstall()
         await self.pipeline.terminate()
+
+    @filter.on_astrbot_loaded()
+    async def on_astrbot_loaded(self):
+        self.runtime_hook.install()
+
+    @filter.on_platform_loaded()
+    async def on_platform_loaded(self):
+        self.runtime_hook.install()
+
+    @filter.on_llm_response(priority=2)
+    async def on_llm_response(
+        self,
+        event: AstrMessageEvent,
+        response: LLMResponse,
+    ):
+        """在发送前同步净化 LLM 输出，按需为 TTS 保留情绪标签。"""
+        tts_instance = self._get_tts_router_instance(event)
+        preserve_emotion_tag, preserve_reason = self._resolve_emotion_tag_policy(
+            event,
+            tts_instance,
+        )
+        self._set_event_extra(event, "_outputpro_preserve_emotion_tag", preserve_emotion_tag)
+        self._set_event_extra(event, "_outputpro_preserve_reason", preserve_reason)
+
+        result_chain = getattr(response, "result_chain", None)
+        chain = getattr(result_chain, "chain", None)
+        if preserve_emotion_tag:
+            completion_text = getattr(response, "completion_text", None)
+            visible_text = collect_visible_text(chain) if chain else ""
+            if not visible_text and isinstance(completion_text, str):
+                visible_text = completion_text
+
+            logger.debug(
+                "[outputpro:on_llm_response] preserve_emotion_tag=%s reason=%s raw=%r",
+                preserve_emotion_tag,
+                preserve_reason,
+                visible_text,
+            )
+            self._block_llm_response_if_needed(response, visible_text)
+            return
+
+        if chain:
+            before_count = len(chain)
+            if tts_instance is not None:
+                transform_text_in_chain(
+                    chain,
+                    lambda value: self._sanitize_with_tts_plugin(tts_instance, value),
+                )
+            sanitize_chain(
+                chain,
+                self.cfg.clean,
+                emotion_tag=True,
+            )
+            replace_in_chain(chain, self.cfg.replace)
+
+            plain = collect_visible_text(chain)
+            logger.debug(
+                "[outputpro:on_llm_response] preserve_emotion_tag=%s reason=%s components=%d->%d plain=%r",
+                preserve_emotion_tag,
+                preserve_reason,
+                before_count,
+                len(chain),
+                plain,
+            )
+            self._block_llm_response_if_needed(response, plain)
+            return
+
+        completion_text = getattr(response, "completion_text", None)
+        updated_text = completion_text if isinstance(completion_text, str) else ""
+        if updated_text and tts_instance is not None:
+            updated_text = self._sanitize_with_tts_plugin(
+                tts_instance,
+                updated_text,
+            )
+        cleaned_text, _ = clean_text(
+            updated_text,
+            self.cfg.clean,
+            emotion_tag=True,
+        )
+        cleaned_text, _ = replace_text(cleaned_text, self.cfg.replace)
+        if isinstance(completion_text, str) and cleaned_text != completion_text:
+            response.completion_text = cleaned_text
+            try:
+                setattr(response, "_completion_text", cleaned_text)
+            except Exception:
+                pass
+
+        logger.debug(
+            "[outputpro:on_llm_response] preserve_emotion_tag=%s reason=%s plain_only=%r",
+            preserve_emotion_tag,
+            preserve_reason,
+            cleaned_text,
+        )
+        self._block_llm_response_if_needed(response, cleaned_text)
 
     @filter.event_message_type(filter.EventMessageType.GROUP_MESSAGE, priority=1000)
     async def on_message(self, event: AstrMessageEvent):
@@ -58,3 +172,172 @@ class OutputPlugin(Star):
         )
 
         await self.pipeline.run(ctx)
+
+    def _block_llm_response_if_needed(self, response: LLMResponse, text: str) -> bool:
+        if not text:
+            return False
+
+        for word in self.cfg.block.block_words:
+            if not word or word not in text:
+                continue
+
+            result_chain = getattr(response, "result_chain", None)
+            chain = getattr(result_chain, "chain", None)
+            if isinstance(chain, list):
+                chain.clear()
+            else:
+                response.completion_text = ""
+            try:
+                setattr(response, "_completion_text", "")
+            except Exception:
+                pass
+            return True
+
+        return False
+
+    def _resolve_emotion_tag_policy(self, event: AstrMessageEvent, tts_instance) -> tuple[bool, str]:
+        marker_mode = self._get_tts_output_marker_mode(event)
+        if marker_mode == TTS_OUTPUT_MARKER_MODE_PRESERVE:
+            return True, "tts_marker_mode_preserve"
+        if marker_mode == TTS_OUTPUT_MARKER_MODE_STRIP:
+            return False, "tts_marker_mode_strip"
+
+        if tts_instance is None:
+            return False, "tts_plugin_missing"
+
+        if not bool(getattr(tts_instance, "emo_marker_enable", False)):
+            return False, "tts_marker_disabled"
+
+        umo = self._resolve_tts_umo(event, tts_instance)
+        if not umo:
+            return False, "tts_umo_unavailable"
+
+        if not self._is_tts_voice_output_enabled(tts_instance, umo):
+            return False, "tts_voice_output_disabled"
+
+        return True, "tts_voice_output_enabled"
+
+    def _get_tts_router_instance(self, event: AstrMessageEvent):
+        for star in self.context.get_all_stars():
+            if not getattr(star, "activated", False):
+                continue
+            if not self._is_tts_emotion_router(star):
+                continue
+            if not self._is_star_enabled_for_event(event, star):
+                continue
+
+            instance = getattr(star, "star_cls", None)
+            if instance is None:
+                continue
+            return instance
+
+        return None
+
+    @staticmethod
+    def _is_tts_emotion_router(star) -> bool:
+        names = {
+            str(getattr(star, "name", "") or ""),
+            str(getattr(star, "display_name", "") or ""),
+            str(getattr(star, "root_dir_name", "") or ""),
+            str(getattr(star, "module_path", "") or ""),
+        }
+        return (
+            TTS_EMOTION_ROUTER_NAME in names
+            or TTS_EMOTION_ROUTER_ROOT in names
+            or any(TTS_EMOTION_ROUTER_ROOT in name for name in names if name)
+        )
+
+    @staticmethod
+    def _is_star_enabled_for_event(event: AstrMessageEvent, star) -> bool:
+        plugins_name = getattr(event, "plugins_name", None)
+        if plugins_name is None or plugins_name == ["*"]:
+            return True
+
+        candidates = {
+            str(getattr(star, "name", "") or ""),
+            str(getattr(star, "display_name", "") or ""),
+            str(getattr(star, "root_dir_name", "") or ""),
+        }
+        return any(candidate and candidate in plugins_name for candidate in candidates)
+
+    @staticmethod
+    def _resolve_tts_umo(event: AstrMessageEvent, instance) -> str:
+        get_umo = getattr(instance, "_get_umo", None)
+        if callable(get_umo):
+            try:
+                umo = get_umo(event)
+                if isinstance(umo, str) and umo:
+                    return umo
+            except Exception:
+                logger.debug(
+                    "[outputpro:on_llm_response] failed to resolve umo via TTS plugin",
+                    exc_info=True,
+                )
+
+        umo = getattr(event, "unified_msg_origin", None)
+        return umo if isinstance(umo, str) else ""
+
+    @staticmethod
+    def _is_tts_voice_output_enabled(instance, umo: str) -> bool:
+        config = getattr(instance, "config", None)
+        checker = getattr(config, "is_voice_output_enabled_for_umo", None)
+        if not callable(checker):
+            return False
+
+        try:
+            return bool(checker(umo))
+        except Exception:
+            logger.debug(
+                "[outputpro:on_llm_response] failed to inspect TTS voice output runtime state",
+                exc_info=True,
+            )
+            return False
+
+    @staticmethod
+    def _get_tts_output_marker_mode(event: AstrMessageEvent) -> str | None:
+        getter = getattr(event, "get_extra", None)
+        if not callable(getter):
+            return None
+
+        try:
+            marker_mode = getter(TTS_OUTPUT_MARKER_MODE_EXTRA)
+        except TypeError:
+            marker_mode = getter(TTS_OUTPUT_MARKER_MODE_EXTRA, None)
+        except Exception:
+            logger.debug(
+                "[outputpro:on_llm_response] failed to read TTS marker mode extra",
+                exc_info=True,
+            )
+            return None
+
+        return marker_mode if isinstance(marker_mode, str) and marker_mode else None
+
+    @staticmethod
+    def _sanitize_with_tts_plugin(tts_instance, text: str) -> str:
+        sanitizer = getattr(tts_instance, "sanitize_visible_output_text", None)
+        if not callable(sanitizer):
+            return text
+
+        try:
+            return sanitizer(text)
+        except Exception:
+            logger.debug(
+                "[outputpro:on_llm_response] failed to sanitize text with TTS plugin helper",
+                exc_info=True,
+            )
+            return text
+
+    @staticmethod
+    def _set_event_extra(event: AstrMessageEvent, key: str, value) -> None:
+        setter = getattr(event, "set_extra", None)
+        if not callable(setter):
+            return
+
+        try:
+            setter(key, value)
+        except Exception:
+            logger.debug(
+                "[outputpro:on_llm_response] failed to set event extra %s",
+                key,
+                exc_info=True,
+            )


### PR DESCRIPTION
## 变更说明
- 基于上游最新 `main` 重新整理并迁移 fork 中的输出链路改动，避免与上游近期更新冲突
- 新增 `RuntimeOutputHook`，在运行时拦截 `send` / `send_streaming` / `send_by_session`，统一执行清洗、替换、错误关键词拦截与屏蔽词拦截
- 抽离 `sanitize` 工具模块，让 `clean` / `replace` 步骤与 LLM 输出发送前清洗共用同一套逻辑
- 在 `on_llm_response` 中按 TTS 情绪路由运行状态决定是否保留情绪标签与停顿标签，并补充 direct-send 场景的错误处理
- 使用 `ruff format` 对涉及文件做了风格对齐

## 验证
- `python3 -m py_compile $(git ls-files '*.py')`\n- `ruff check main.py core/runtime_hook.py core/sanitize.py core/step/clean.py core/step/replace.py`\n- `ruff format --check main.py core/runtime_hook.py core/sanitize.py core/step/clean.py core/step/replace.py`\n\n## 备注\n- 保持 `metadata.yaml` 的仓库地址与上游版本号不变，避免在功能 PR 中引入发布元数据噪音\n- 当前没有发现与上游 `split` / typing 相关更新的实际冲突

## Summary by Sourcery

引入一个共享的运行时输出清洗管线（pipeline），支持保护 TTS 标记，并将其集成到管线步骤和运行时发送钩子中。

新功能：
- 新增 `RuntimeOutputHook`，用于拦截 `AstrMessageEvent` 以及 Platform 的 `send` / `send_streaming` / `send_by_session` 调用，实现统一的输出清洗、内容替换和基于关键词的阻断。
- 在清洗 LLM 响应时，根据 TTS emotion router 的运行时状态，支持保留 TTS 情绪与停顿标签。

增强改进：
- 将文本清洗和替换逻辑重构为可复用的 `sanitize` 模块，供管线步骤和运行时钩子共同使用，包括更丰富的标签/emoji/括号处理以及可见文本收集能力。
- 更新 clean 与 replace 步骤，使其委托给共享的 sanitize 工具，并调整对被移除和被替换内容的报告格式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a shared runtime output sanitization pipeline with TTS marker protection and integrate it into both pipeline steps and runtime send hooks.

New Features:
- Add a RuntimeOutputHook to intercept AstrMessageEvent and Platform send/send_streaming/send_by_session calls for unified output cleaning, replacement, and keyword-based blocking.
- Support TTS emotion and pause tag preservation based on the TTS emotion router runtime state when sanitizing LLM responses.

Enhancements:
- Refactor text cleaning and replacement logic into a reusable sanitize module used by both pipeline steps and runtime hooks, including richer tag/emoji/bracket handling and visible text collection.
- Update clean and replace steps to delegate to the shared sanitize utilities and adjust their reporting format for removed and replaced content.

</details>