### PR TITLE
fix: trim whitespace around split segments

### DIFF
--- a/core/step/split.py
+++ b/core/step/split.py
@@ -45,6 +45,20 @@ class Segment:
         """是否为空段（无文本、无媒体）"""
         return not self.text.strip() and not self.has_media
 
+    def lstrip_plain(self):
+        """去除段首 Plain 的前导空白。"""
+        for comp in self.components:
+            if isinstance(comp, Plain):
+                comp.text = comp.text.lstrip()
+                break
+
+    def rstrip_plain(self):
+        """去除段尾 Plain 的尾随空白。"""
+        for comp in reversed(self.components):
+            if isinstance(comp, Plain):
+                comp.text = comp.text.rstrip()
+                break
+
 
 class SplitStep(BaseStep):
     name = StepName.SPLIT
@@ -82,6 +96,11 @@ class SplitStep(BaseStep):
         最后一段会回填到原 chain 中。
         """
         segments = self._split_chain(ctx.chain)
+
+        # 清理每个分段边界的空白，避免分段消息开头出现多余空格/换行。
+        for seg in segments:
+            seg.lstrip_plain()
+            seg.rstrip_plain()
 
         if len(segments) <= 1:
             return StepResult()


### PR DESCRIPTION
## 修复内容

Fixes #75

本 PR 修复 `split` 分段回复后，后续分段开头可能残留空格或无效换行的问题。

具体改动：

- 为 `Segment` 增加 `lstrip_plain()`，清理段首 `Plain` 的前导空白
- 为 `Segment` 增加 `rstrip_plain()`，清理段尾 `Plain` 的尾随空白
- 在 `_split_chain()` 生成分段后统一执行边界清理

## 背景

在 QQ / aiocqhttp 实测中，如果原始回复文本在分隔符后带有空格、换行，或 Markdown 硬换行残留，split 后的第二段、第三段可能会以空白开头，实际发送时观感异常。

该修复只清理分段边界，不改动段内正常文本。

## 验证

- 本地通过：

```bash
python -m py_compile core/step/split.py
```

- 在 AstrBot 实例中重载插件后，普通句号分段测试正常，后续分段开头不再出现多余空格。

## Summary by Sourcery

Bug Fixes:
- 移除每个拆分片段中第一个 Plain 组件前导空格以及最后一个 Plain 组件尾随空格，防止片段在开头或结尾出现非预期的空白字符。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Remove leading whitespace from the first Plain component and trailing whitespace from the last Plain component of each split segment to prevent segments from starting or ending with unintended blanks.

</details>