### PR TITLE
feat: 修复空艾特问题

### DIFF
--- a/core/step/at.py
+++ b/core/step/at.py
@@ -4,8 +4,6 @@ import re
 from astrbot.core.message.components import (
     At,
     BaseMessageComponent,
-    Face,
-    Image,
     Plain,
     Reply,
 )
@@ -47,10 +45,10 @@ class AtStep(BaseStep):
             if not isinstance(seg, Plain):
                 continue
 
-            if self.cfg.at_str and nickname:
+            if (self.cfg.at_str or not qq) and nickname:
                 # 原地修改
                 seg.text = f"@{nickname} " + seg.text
-            else:
+            elif qq:
                 # 真 At：插在 Plain 前
                 chain.insert(i, At(qq=qq))
                 chain.insert(i + 1, Plain("\u200b"))
@@ -115,7 +113,7 @@ class AtStep(BaseStep):
         # ===== 2. 智能艾特 =====
         if not (
             self.cfg.at_prob > 0
-            and all(isinstance(c, Plain | Image | Face | At | Reply) for c in ctx.chain)
+            and all(isinstance(c, Plain | At | Reply) for c in ctx.chain)
         ):
             return StepResult()
 

--- a/core/step/split.py
+++ b/core/step/split.py
@@ -41,12 +41,13 @@ class Segment:
 
     @property
     def is_empty(self) -> bool:
-        return not self.has_media or all(
-            isinstance(c, (At, Reply)) for c in self.components
-        )
+        if self.text.strip():
+            return False
+        if not self.has_media:
+            return True
+        return all(isinstance(c, (At, Reply)) for c in self.components)
 
     def strip_plain(self):
-        """去除 Plain 首尾空白，但保留 At 后的一个空格"""
         prev_is_at = False
         new_components = []
         for c in self.components:
@@ -55,17 +56,16 @@ class Segment:
                 new_components.append(c)
                 continue
             if isinstance(c, Plain):
-                # 真正丢弃全空白 Plain
                 if not c.text.replace("\u200b", "").strip():
-                    prev_is_at = False
                     continue
                 stripped = c.text.strip()
                 c.text = " " + stripped if prev_is_at else stripped
                 new_components.append(c)
-            else:
-                new_components.append(c)
+                prev_is_at = False
+                continue
+            new_components.append(c)
             prev_is_at = False
-        self.components = new_components
+        self.components[:] = new_components
 
     def strip_tail_punc(self, pattern):
         """去掉尾部标点（仅最后一个 Plain 生效）"""

--- a/core/step/split.py
+++ b/core/step/split.py
@@ -41,20 +41,31 @@ class Segment:
 
     @property
     def is_empty(self) -> bool:
-        return not self.text.strip() and not self.has_media
+        return not self.has_media or all(
+            isinstance(c, (At, Reply)) for c in self.components
+        )
 
     def strip_plain(self):
         """去除 Plain 首尾空白，但保留 At 后的一个空格"""
         prev_is_at = False
+        new_components = []
         for c in self.components:
             if isinstance(c, At):
                 prev_is_at = True
+                new_components.append(c)
                 continue
             if isinstance(c, Plain):
+                # 真正丢弃全空白 Plain
                 if not c.text.replace("\u200b", "").strip():
+                    prev_is_at = False
                     continue
                 stripped = c.text.strip()
                 c.text = " " + stripped if prev_is_at else stripped
+                new_components.append(c)
+            else:
+                new_components.append(c)
+            prev_is_at = False
+        self.components = new_components
 
     def strip_tail_punc(self, pattern):
         """去掉尾部标点（仅最后一个 Plain 生效）"""
@@ -299,7 +310,13 @@ class TypingController:
 # =========================
 class SplitStep(BaseStep):
     name = StepName.SPLIT
-    support_platforms = {"aiocqhttp", "telegram", "lark","qq_official", "qq_official_webhook"}
+    support_platforms = {
+        "aiocqhttp",
+        "telegram",
+        "lark",
+        "qq_official",
+        "qq_official_webhook",
+    }
 
     def __init__(self, config: PluginConfig):
         super().__init__(config)


### PR DESCRIPTION
## Summary by Sourcery

在内容仅由提及或回复组成时，防止发送空消息，并收紧智能 @ 插入行为。

Bug 修复：
- 将仅包含提及或回复组件且没有媒体内容的消息视为空消息，以避免发送空白内容。
- 在剥离消息内容时跳过纯空白的文本片段，减少无意义的负载。
- 将智能提及插入限制在受支持的组件类型上，当没有目标 ID 可用时回退到基于文本的提及。

增强：
- 优化纯文本剥离逻辑，以保留有意义的内容，并从消息链中移除空组件。
- 为了一致性，略微重新格式化分割步骤中的受支持平台列表。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent sending empty messages when content consists only of mentions or replies and tighten smart @ insertion behavior.

Bug Fixes:
- Treat messages that contain only mention or reply components without media as empty to avoid sending blank content.
- Skip text segments that are purely whitespace when stripping message content to reduce meaningless payload.
- Limit smart mention insertion to supported component types and fall back to text-based mentions when no target ID is available.

Enhancements:
- Refine plain-text stripping to preserve meaningful content and remove empty components from the message chain.
- Slightly reformat supported platform list for the split step for consistency.

</details>

Bug 修复：
- 将仅包含提及或回复组件且不带媒体的消息视为“空”，以防止发送空内容。
- 在剥离消息内容时跳过仅包含空白字符的文本片段，避免产生无意义的负载。
- 调整智能提及插入逻辑：在没有目标 ID 时改用基于文本的提及，并将处理限制在受支持的组件类型范围内。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在内容仅由提及或回复组成时，防止发送空消息，并收紧智能 @ 插入行为。

Bug 修复：
- 将仅包含提及或回复组件且没有媒体内容的消息视为空消息，以避免发送空白内容。
- 在剥离消息内容时跳过纯空白的文本片段，减少无意义的负载。
- 将智能提及插入限制在受支持的组件类型上，当没有目标 ID 可用时回退到基于文本的提及。

增强：
- 优化纯文本剥离逻辑，以保留有意义的内容，并从消息链中移除空组件。
- 为了一致性，略微重新格式化分割步骤中的受支持平台列表。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent sending empty messages when content consists only of mentions or replies and tighten smart @ insertion behavior.

Bug Fixes:
- Treat messages that contain only mention or reply components without media as empty to avoid sending blank content.
- Skip text segments that are purely whitespace when stripping message content to reduce meaningless payload.
- Limit smart mention insertion to supported component types and fall back to text-based mentions when no target ID is available.

Enhancements:
- Refine plain-text stripping to preserve meaningful content and remove empty components from the message chain.
- Slightly reformat supported platform list for the split step for consistency.

</details>

</details>