### PR TITLE
fix: 修复错字追加纠正时 _split_chain 缺少 max_count 参数导致的 TypeError

### DIFF
--- a/core/step/typo.py
+++ b/core/step/typo.py
@@ -377,7 +377,7 @@ class TypoStep(BaseStep):
         from .split import SplitStep
 
         split_step = SplitStep(self.plugin_config)
-        preview_segments = split_step._split_chain(preview_chain)
+        preview_segments = split_step._split_chain(preview_chain, self.plugin_config.split.max_count)
         if len(preview_segments) <= 1:
             return False
 


### PR DESCRIPTION
### 问题

`core/step/typo.py` 的 `_should_append_correction()` 调用 `SplitStep._split_chain(preview_chain)` 时只传了一个参数，而 `_split_chain(self, chain, max_count)` 的 `max_count` 是必填参数，触发"追加纠正"时必现：

```
TypeError: SplitStep._split_chain() missing 1 required positional argument: 'max_count'
```

### 修复

按 `split.py` 内部调用惯例（`self._split_chain(ctx.chain, self.cfg.max_count)`）补传分段上限：

```diff
-        preview_segments = split_step._split_chain(preview_chain)
+        preview_segments = split_step._split_chain(preview_chain, self.plugin_config.split.max_count)
```

### 验证

- 传参与 `SplitStep` 内部调用完全一致（`split.max_count`）
- 已在自部署环境按此修复运行验证：错字 + 追加纠正 + 分段开启场景不再抛错，纠正文本正常追加

Fixes #87

## Sourcery 摘要

错误修复：
- 修复错字追加纠正与分段同时启用时因缺少分段数量上限参数而触发的 TypeError。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 修复错字追加纠正与分段同时启用时因缺少分段数量上限参数而触发的 TypeError。

</details>