### PR TITLE
Update forward.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## v2.2.7
+
+错误修复：
+
+- SplitStep._split_chain() 必填参数 max_count 改为选填，避免错字模拟逻辑调用时报错
+- 从 aiocqhttp 转发的消息中过滤Reply组件，并跳过创建空的转发节点。
+
 ## v2.2.6
 
 - 修复错误的插件数据目录

--- a/core/step/forward.py
+++ b/core/step/forward.py
@@ -186,9 +186,6 @@ class ForwardStep(BaseStep):
                     for component in ctx.chain
                     if not isinstance(component, Reply)
                 ]
-                if not content:
-                    ctx.chain.clear()
-                    return StepResult(msg="过滤 Reply 后无有效转发内容，已跳过合并转发")
                 nodes = Nodes([])
                 name = await self._ensure_node_name(ctx.event)
                 uin = str(ctx.event.get_self_id() or ctx.bid)

--- a/core/step/forward.py
+++ b/core/step/forward.py
@@ -2,6 +2,7 @@ from astrbot.core.message.components import (
     Node,
     Nodes,
     Plain,
+    Reply,
 )
 from astrbot.core.platform.astr_message_event import AstrMessageEvent
 from astrbot.core.platform.sources.aiocqhttp.aiocqhttp_message_event import (
@@ -180,10 +181,17 @@ class ForwardStep(BaseStep):
             platform_name = ctx.event.get_platform_name()
 
             if platform_name == "aiocqhttp":
+                content = [
+                    component
+                    for component in ctx.chain
+                    if not isinstance(component, Reply)
+                ]
+                if not content:
+                    ctx.chain.clear()
+                    return StepResult(msg="过滤 Reply 后无有效转发内容，已跳过合并转发")
                 nodes = Nodes([])
                 name = await self._ensure_node_name(ctx.event)
                 uin = str(ctx.event.get_self_id() or ctx.bid)
-                content = list(ctx.chain.copy())
                 nodes.nodes.append(Node(uin=uin, name=name, content=content))
                 ctx.chain[:] = [nodes]
                 return StepResult(msg="已将消息转换为转发节点")

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,6 +2,6 @@ name: astrbot_plugin_outputpro
 display_name: 输出增强
 desc: Astrbot输出管道：图片外显 → 报错处理 → 消息拦截 → 解析艾特 → 文本清洗 → 文本替换 → 错字模拟 → 文转语音 → 文转图片 → 智能引用 → 合并转发 → 自动撤回 → 分段回复
 help: 略
-version: v2.2.6
+version: v2.2.7
 author: Zhalslar
 repo: https://github.com/Zhalslar/astrbot_plugin_outputpro


### PR DESCRIPTION
## Sourcery 摘要

从 aiocqhttp 转发的消息中过滤仅回复内容，并跳过创建空的转发节点。

错误修复：
- 通过排除 Reply 组件，并在没有剩余有效内容时跳过转发，防止生成空的转发消息。

增强功能：
- 将 aiocqhttp 消息转换为转发节点时，保留有效的消息组件。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

将 aiocqhttp 消息转换为转发节点时过滤回复组件，并避免创建没有有效内容的节点。

Bug 修复：
- 在转换 aiocqhttp 消息时排除仅包含回复的组件，防止生成空的转发消息节点。

增强功能：
- 将 aiocqhttp 消息转换为转发节点时，保留所有有效的非回复消息组件。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

修复 aiocqhttp 消息转发时仅含回复内容导致空节点的问题。

修复：
- 过滤 aiocqhttp 转发消息中的 Reply 组件，避免生成空的转发节点。

维护：
- 将插件版本更新至 v2.2.7，并记录相关变更。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复 aiocqhttp 消息转发时仅含回复内容导致空节点的问题。

Bug Fixes:
- 过滤 aiocqhttp 转发消息中的 Reply 组件，避免生成空的转发节点。

Chores:
- 将插件版本更新至 v2.2.7，并记录相关变更。

</details>

</details>

</details>